### PR TITLE
Fix `dxvk` target version

### DIFF
--- a/versions
+++ b/versions
@@ -1,4 +1,4 @@
 # target versions to install
-dxvk_version_target="2.0.0"
+dxvk_version_target="2.0"
 dfc_version_target="2022.10.0"
 java_download_url_target="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.5%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.5_8.tar.gz"


### PR DESCRIPTION
Removes semver patch zero from `dxvk` target version. Otherwise, the `404 Not Found` is thrown.

See https://github.com/doitsujin/dxvk/releases/tag/v2.0