### PR TITLE
Update DXVK to 2.3

### DIFF
--- a/versions
+++ b/versions
@@ -1,4 +1,4 @@
 # target versions to install
-dxvk_version_target="2.2"
+dxvk_version_target="2.3"
 dfc_version_target="2023.12.1"
 java_download_url_target="https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz"


### PR DESCRIPTION
Version 2.3 of DXVK was available for some time and it works without an issue.