### PR TITLE
corrected WMClass for the desktop entry

### DIFF
--- a/install-shortcut.sh
+++ b/install-shortcut.sh
@@ -19,6 +19,7 @@ Comment=Lobby client for Supreme Commander: Forged Alliance (faf-linux)
 Exec=$basedir/run
 Type=Application
 Icon=$basedir/faf-logo.png
+StartupWMClass=com.faforever.client.FafClientApplication
 Categories=Network;Game;
 EOF
 chmod a+x "$dest_path"


### PR DESCRIPTION
The desktop entry name didn't match the WMClass of the FAF application window, resulting in wrong icon and in case of pinned entry, duplicate instances on the dash. 